### PR TITLE
Set errors and fields variables from config

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -40,11 +40,11 @@ class LivrPlugin {
     Vue.mixin(mixin);
   }
 
-  initVM() {
+  initVM({ errorBagName, fieldsBagName }) {
     this._vm = new Vue({
       data: () => ({
-        errors: this.livrInstance.errors,
-        fields: this.livrInstance.fields,
+        [errorBagName]: this.livrInstance.errors,
+        [fieldsBagName]: this.livrInstance.fields,
       }),
     });
   }


### PR DESCRIPTION
In order to avoid conflicts between `vue-livr` and other plugins, now the user can set custom names for the errorBag and fieldsBag. 

```
Vue.use(VueLIVR, {
  extraRules: {}, // Extra rules to be added
  patchRules: false, // Patch rules to return extended error codes
  errorHandlers: {}, // Error handler to each error code that LIVR returns, it will run only if patchRules
  errorBagName: 'errors',
  fieldsBagName: 'fields'
});
```