### PR TITLE
Hotfix/patch rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Vue.use(VueLIVR, {
   extraRules: {}, // Extra rules to be added
   extendedErrors: false, // Patch rules to return extended error codes
   errorHandlers: {}, // Error handler to each error code that LIVR returns, it will run only if extendedErrors = true
-  aliasedRules: [], // aliasedRules to register
+  aliasedRules: [], // list of aliasedRules to register
 });
 ```
 
@@ -46,6 +46,59 @@ export default {
       const { name } = this;
       this.$livr.validate(livrRules, { name }, field);
     },
+  },
+};
+```
+
+## Array example
+
+```html
+<div v-for="(form, index) in forms" :key="index"> 
+  <input 
+    class="listing-units__input" 
+    v-model="form.name"
+    @blur="validate('name', index)"
+    :class="{ invalid: hasErrorMessage('name', index) }"
+  />
+  <span>{{getErrorMessage('name', index)}}</span>
+</div>
+
+<button @click="validateAll">Validate All</button>
+```
+
+
+
+```js
+const livrRules = {
+  forms: ['required', {
+    list_of_objects: [{
+      name: ['required', { min_length: 1 }],
+    }],
+  }],
+};
+
+export default {
+  data() {
+    return {
+      forms: [{ name: '' }, { name: ''}],
+    };
+  },
+  methods: {
+    validate(field, index) {
+      const fieldName = `forms[${index}].${field}[0]`;
+      this.$livr.validate(livrRules, this.forms, fieldName);
+    },
+    validateAll() {
+      this.$livr.validateAll(livrRules, this.forms);
+    },
+    hasErrorMessage(field, index) {
+      const fieldName = `forms[${index}].${field}[0]`
+      return this.errors.hasError(fieldName);
+    },
+    getErrorMessage(field, index) {
+      const fieldName = `forms[${index}].${field}[0]`;
+      return this.errors.getError(fieldName);
+    }
   },
 };
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-livr",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-livr",
-  "version": "0.0.5",
+  "version": "0.0.1",
   "description": "Vue LIVR plugin",
   "author": "Jonatas Gusmão <js.gusmao@hotmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-livr",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "description": "Vue LIVR plugin",
   "author": "Jonatas Gusmão <js.gusmao@hotmail.com>",
   "license": "MIT",

--- a/src/livr/error/index.js
+++ b/src/livr/error/index.js
@@ -2,17 +2,20 @@ import set from 'lodash/set';
 import get from 'lodash/get';
 import getMessage from './handler';
 
-const getErrorMessages = (errors, handlers, objectPath = []) =>
-  Object.entries(errors).reduce((agg, [field, error]) => {
+const getErrorMessages = (errors, handlers, objectPath = []) => {
+  const isArray = Array.isArray(errors);
+
+  return Object.entries(errors).reduce((agg, [field, error]) => {
     let path = [].concat(objectPath);
-    path.push(field);
-    if (error.code) {
+    if (!isArray) { path.push(field) };
+    
+    if (error && error.code) {
       const [[, ruleValue]] = Object.entries(error.rule);
       Object.assign(error, {
         msg: getMessage(handlers, path.join('.'), error.code, ruleValue),
       });
       path = [];
-    } else {
+    } else if (error) {
       getErrorMessages(error, handlers, path);
     }
 
@@ -20,6 +23,7 @@ const getErrorMessages = (errors, handlers, objectPath = []) =>
       [field]: error,
     });
   }, {});
+}
 
 export default class LivrError {
   constructor(livrError, options = {}) {
@@ -74,7 +78,6 @@ export default class LivrError {
     }
 
     const msgPath = this.extendedErrors ? '.msg' : '';
-
     return get(this.items, `${field}${msgPath}`, '');
   }
 

--- a/src/livr/index.js
+++ b/src/livr/index.js
@@ -40,12 +40,12 @@ export default class Livr {
   }
 
   validate(validations, fields, field) {
-    this.validator = new LIVR.Validator(validations);
-    const valid = this.validator.validate(fields);
-    const result = valid || this.validator.getErrors();
+    const validator = new LIVR.Validator(validations);
+    const valid = validator.validate(fields);
+    const result = valid || validator.getErrors();
 
     if (!valid) {
-      this.errors.setError(result, field);
+      this.errors.setError(Object.assign({}, result), field);
       this.errors.setTouched(field);
       return { errors: this.errors.items };
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,11 +12,7 @@ export const patchRule = (ruleName, ruleBuilder) => {
           [ruleName]: ruleArgs,
         };
 
-        if (Array.isArray(errorCode)) {
-          return errorCode[0];
-        }
-
-        if (isObject(errorCode)) {
+        if (Array.isArray(errorCode) || isObject(errorCode)) {
           return errorCode;
         }
 


### PR DESCRIPTION
What
Fix how list field errors were handled by the plugin, more specifically the patchRules method

Why
It was impossible to validate an array with elements with the same field name in the old way
@shinrox did a terrible job on this.... yucks