### PR TITLE
Hotfix/clear errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-livr",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Vue LIVR plugin",
   "author": "Jonatas Gusmão <js.gusmao@hotmail.com>",
   "license": "MIT",

--- a/src/livr/error/index.js
+++ b/src/livr/error/index.js
@@ -7,8 +7,10 @@ const getErrorMessages = (errors, handlers, objectPath = []) => {
 
   return Object.entries(errors).reduce((agg, [field, error]) => {
     let path = [].concat(objectPath);
-    if (!isArray) { path.push(field) };
-    
+    if (!isArray) {
+      path.push(field);
+    }
+
     if (error && error.code) {
       const [[, ruleValue]] = Object.entries(error.rule);
       Object.assign(error, {
@@ -23,7 +25,7 @@ const getErrorMessages = (errors, handlers, objectPath = []) => {
       [field]: error,
     });
   }, {});
-}
+};
 
 export default class LivrError {
   constructor(livrError, options = {}) {
@@ -62,10 +64,10 @@ export default class LivrError {
     }
   }
 
-  clearErrors(items = this.items) {
-    Object.entries(items).forEach(([key, value]) =>
-      typeof value === 'object' ? this.clearErrors(value) : this.clearError(key),
-    );
+  clearErrors(errors = ({ items = {} } = this)) {
+    Object.entries(errors).forEach(([key, value]) => {
+      return typeof value === 'object' ? this.clearErrors(value) : this.clearError(key);
+    });
   }
 
   clearError(field) {

--- a/src/livr/error/index.js
+++ b/src/livr/error/index.js
@@ -64,7 +64,10 @@ export default class LivrError {
     }
   }
 
-  clearErrors(errors = ({ items = {} } = this)) {
+  clearErrors(errors = this.items) {
+    if (!errors) {
+      return;
+    }
     Object.entries(errors).forEach(([key, value]) => {
       return typeof value === 'object' ? this.clearErrors(value) : this.clearError(key);
     });

--- a/src/livr/error/index.spec.js
+++ b/src/livr/error/index.spec.js
@@ -31,4 +31,10 @@ describe('Error - Index', () => {
     clearErrorsSpy.mockRestore();
     clearErrorSpy.mockRestore();
   });
+
+  it('should not thrown an error when called without arg', () => {
+    expect(() => error.clearErrors()).not.toThrow();
+    expect(() => error.clearErrors(null)).not.toThrow();
+    expect(() => error.clearErrors(undefined)).not.toThrow();
+  });
 });


### PR DESCRIPTION
What
Fix clearErrors method

Why
It was generating an error when called with a null or undefined param