### PR TITLE
Feature/livr error array

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,52 +53,47 @@ export default {
 ## Array example
 
 ```html
-<div v-for="(form, index) in forms" :key="index"> 
-  <input 
-    class="listing-units__input" 
-    v-model="form.name"
+<div v-for="(user, index) in users" :key="index">
+  <input
+    class="listing-units__input"
+    v-model="user.name"
     @blur="validate('name', index)"
-    :class="{ invalid: hasErrorMessage('name', index) }"
+    :class="{ invalid: errors.hasError('name', index) }"
   />
-  <span>{{getErrorMessage('name', index)}}</span>
+  <span>{{errors.getError('name', index)}}</span>
 </div>
 
 <button @click="validateAll">Validate All</button>
 ```
 
-
-
 ```js
 const livrRules = {
-  forms: ['required', {
-    list_of_objects: [{
-      name: ['required', { min_length: 1 }],
-    }],
-  }],
+  users: [
+    'required',
+    {
+      list_of_objects: [
+        {
+          name: ['required', { min_length: 1 }],
+        },
+      ],
+    },
+  ],
 };
 
 export default {
   data() {
     return {
-      forms: [{ name: '' }, { name: ''}],
+      users: [{ name: '' }, { name: '' }],
     };
   },
   methods: {
     validate(field, index) {
-      const fieldName = `forms[${index}].${field}[0]`;
-      this.$livr.validate(livrRules, this.forms, fieldName);
+      const fieldName = `users[${index}].${field}[0]`;
+      this.$livr.validate(livrRules, this.users, fieldName);
     },
     validateAll() {
-      this.$livr.validateAll(livrRules, this.forms);
+      this.$livr.validateAll(livrRules, this.users);
     },
-    hasErrorMessage(field, index) {
-      const fieldName = `forms[${index}].${field}[0]`
-      return this.errors.hasError(fieldName);
-    },
-    getErrorMessage(field, index) {
-      const fieldName = `forms[${index}].${field}[0]`;
-      return this.errors.getError(fieldName);
-    }
   },
 };
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-livr",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Vue LIVR plugin",
   "author": "Jonatas Gusmão <js.gusmao@hotmail.com>",
   "license": "MIT",

--- a/src/livr/error/index.js
+++ b/src/livr/error/index.js
@@ -89,7 +89,7 @@ export default class LivrError {
   }
 
   getMessage(error) {
-    return this.msgPath ? error[this.msgPath] : error;
+    return this.msgPath && error ? error[this.msgPath] : error;
   }
 
   getFirstError(field) {

--- a/src/livr/error/index.spec.js
+++ b/src/livr/error/index.spec.js
@@ -58,9 +58,11 @@ describe('Error - Index', () => {
   });
 
   it('should return error message for a different index', () => {
-    error.setError({ field: [null, 'message'] }, 'field');
+    error.setError({ field: [undefined, 'message'] }, 'field');
     error.setTouched('field');
     expect(error.hasError('field', 0)).toBeFalsy();
     expect(error.hasError('field', 1)).toBeTruthy();
+    expect(error.getError('field', 0)).toBe('');
+    expect(error.getError('field', 1)).toBe('message');
   });
 });

--- a/src/livr/error/index.spec.js
+++ b/src/livr/error/index.spec.js
@@ -37,4 +37,30 @@ describe('Error - Index', () => {
     expect(() => error.clearErrors(null)).not.toThrow();
     expect(() => error.clearErrors(undefined)).not.toThrow();
   });
+
+  it('should not return error message when field not touched', () => {
+    error.setError({ field: 'message' }, 'field');
+    expect(error.hasError('field')).toBeFalsy();
+  });
+
+  it('should return error message when allTouched is true and field is not touched', () => {
+    error.setError({ field: 'message' }, 'field');
+    error.setAllTouched(true);
+    expect(error.hasError('field')).toBeTruthy();
+  });
+
+  it('should return error message when allTouched false true and field is touched', () => {
+    error.setError({ field: 'message' }, 'field');
+    error.setAllTouched(false);
+    error.setTouched('field');
+
+    expect(error.hasError('field')).toBeTruthy();
+  });
+
+  it('should return error message for a different index', () => {
+    error.setError({ field: [null, 'message'] }, 'field');
+    error.setTouched('field');
+    expect(error.hasError('field', 0)).toBeFalsy();
+    expect(error.hasError('field', 1)).toBeTruthy();
+  });
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -40,4 +40,8 @@ export const isBuiltInComponent = vnode => {
   return /^(keep-alive|transition|transition-group)$/.test(tag);
 };
 
+export const isNoValue = value => value === null || typeof value === 'undefined' || value === '';
+
+export const isValue = value => !isNoValue(value);
+
 export default {};


### PR DESCRIPTION
What
Always handle LIVR errors as arrays
Update `getError` method to return the first error
Add new `getErrors` method to return all field errors